### PR TITLE
feat: add URL button variable support for WhatsApp templates

### DIFF
--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
@@ -67,6 +67,9 @@
           />
         </div>
       </div>
+      <p v-if="hasEmptyButtonParams && buttonParamsTouched" class="error">
+        {{ $t('WHATSAPP_TEMPLATES.PARSER.FORM_ERROR_MESSAGE') }}
+      </p>
     </div>
     <footer>
       <woot-button
@@ -132,11 +135,15 @@ export default {
     return {
       processedParams: {},
       buttonParams: [],
+      buttonParamsTouched: false,
       disableResetButton: true,
       eventVariables: {},
     };
   },
   computed: {
+    hasEmptyButtonParams() {
+      return this.buttonParams.some(p => !p.value.trim());
+    },
     variables() {
       const variables = this.templateString.match(/{{([^}]+)}}/g);
       return variables;
@@ -170,6 +177,12 @@ export default {
     },
   },
 
+  watch: {
+    template() {
+      this.initButtonParams();
+      this.buttonParamsTouched = false;
+    },
+  },
   mounted() {
     this.generateVariables();
     this.initButtonParams();
@@ -187,6 +200,8 @@ export default {
     sendMessage() {
       this.$v.$touch();
       if (this.$v.$invalid) return;
+      this.buttonParamsTouched = true;
+      if (this.hasEmptyButtonParams) return;
       const payload = {
         message: this.processedString,
         templateParams: {

--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
@@ -43,6 +43,24 @@
         {{ $t('WHATSAPP_TEMPLATES.PARSER.FORM_ERROR_MESSAGE') }}
       </p>
     </div>
+    <div v-if="urlButtons.length > 0" class="template__variables-container">
+      <p class="variables-label">
+        {{ $t('WHATSAPP_TEMPLATES.PARSER.BUTTON_VARIABLES_LABEL') }}
+      </p>
+      <div
+        v-for="(btn, i) in urlButtons"
+        :key="'btn-' + i"
+        class="template__variable-item"
+      >
+        <span class="variable-label">{{ btn.text }}</span>
+        <woot-input
+          v-model="buttonParams[i].value"
+          type="text"
+          class="variable-input"
+          :styles="{ marginBottom: 0 }"
+        />
+      </div>
+    </div>
     <footer>
       <woot-button
         :disabled="disableResetButton"
@@ -106,6 +124,7 @@ export default {
   data() {
     return {
       processedParams: {},
+      buttonParams: [],
       disableResetButton: true,
       eventVariables: {},
     };
@@ -119,6 +138,15 @@ export default {
       return this.template.components.find(
         component => component.type === 'BODY'
       ).text;
+    },
+    urlButtons() {
+      const buttonsComponent = this.template.components.find(
+        c => c.type === 'BUTTONS'
+      );
+      if (!buttonsComponent) return [];
+      return buttonsComponent.buttons
+        .map((btn, index) => ({ ...btn, index }))
+        .filter(btn => btn.type === 'URL' && btn.url && btn.url.includes('{{'));
     },
 
     processedString() {
@@ -137,6 +165,7 @@ export default {
 
   mounted() {
     this.generateVariables();
+    this.initButtonParams();
     this.setDisableResetButton();
 
     if (this.selectedParams) {
@@ -144,7 +173,6 @@ export default {
     }
 
     if (this.selectedEventParams) {
-      console.log(this.selectedEventParams);
       this.eventVariables = this.selectedEventParams;
     }
   },
@@ -160,9 +188,16 @@ export default {
           language: this.template.language,
           namespace: this.template.namespace,
           processed_params: this.processedParams,
+          button_params: this.buttonParams,
         },
       };
       this.$emit('sendMessage', payload);
+    },
+    initButtonParams() {
+      this.buttonParams = this.urlButtons.map(btn => ({
+        index: btn.index,
+        value: '',
+      }));
     },
     processVariable(str) {
       return str.replace(/{{|}}/g, '');

--- a/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
+++ b/app/javascript/dashboard/components/widgets/conversation/WhatsappTemplates/TemplateParser.vue
@@ -50,15 +50,22 @@
       <div
         v-for="(btn, i) in urlButtons"
         :key="'btn-' + i"
-        class="template__variable-item"
+        class="template__button-item"
       >
-        <span class="variable-label">{{ btn.text }}</span>
-        <woot-input
-          v-model="buttonParams[i].value"
-          type="text"
-          class="variable-input"
-          :styles="{ marginBottom: 0 }"
-        />
+        <div class="button-item__header">
+          <span class="variable-label">{{ btn.text }}</span>
+          <span class="button-type-badge">URL</span>
+        </div>
+        <div class="button-item__url-hint">
+          <span class="url-hint-text">{{ urlWithoutVariable(btn.url) }}</span>
+          <woot-input
+            v-model="buttonParams[i].value"
+            type="text"
+            class="variable-input"
+            :placeholder="urlVariablePlaceholder(btn.url)"
+            :styles="{ marginBottom: 0 }"
+          />
+        </div>
       </div>
     </div>
     <footer>
@@ -228,6 +235,13 @@ export default {
         this.disableResetButton = false;
       }, 100);
     },
+    urlWithoutVariable(url) {
+      return url.replace(/\{\{[^}]+\}\}.*$/, '');
+    },
+    urlVariablePlaceholder(url) {
+      const match = url.match(/\{\{([^}]+)\}\}/);
+      return match ? `{{${match[1]}}}` : '';
+    },
   },
 };
 </script>
@@ -254,6 +268,34 @@ export default {
 
   .variable-label {
     @apply bg-slate-75 dark:bg-slate-700 text-slate-700 dark:text-slate-100 inline-block rounded-md text-xs py-2.5 px-6;
+  }
+}
+
+.template__button-item {
+  @apply mb-3;
+
+  .button-item__header {
+    @apply flex items-center gap-2 mb-1.5;
+  }
+
+  .button-item__url-hint {
+    @apply flex items-center;
+  }
+
+  .url-hint-text {
+    @apply text-xs text-slate-500 dark:text-slate-400 font-mono whitespace-nowrap;
+  }
+
+  .variable-input {
+    @apply flex-1 text-sm ml-1;
+  }
+
+  .variable-label {
+    @apply bg-slate-75 dark:bg-slate-700 text-slate-700 dark:text-slate-100 inline-block rounded-md text-xs py-2.5 px-6;
+  }
+
+  .button-type-badge {
+    @apply bg-woot-75 dark:bg-woot-800 text-woot-600 dark:text-woot-200 text-xs font-semibold rounded px-1.5 py-0.5;
   }
 }
 

--- a/app/javascript/dashboard/i18n/locale/en/whatsappTemplates.json
+++ b/app/javascript/dashboard/i18n/locale/en/whatsappTemplates.json
@@ -17,6 +17,7 @@
         "PARSER": {
             "VARIABLES_LABEL": "Variables",
             "VARIABLE_PLACEHOLDER": "Enter %{variable} value",
+            "BUTTON_VARIABLES_LABEL": "Button variables",
             "GO_BACK_LABEL": "Go Back",
             "SEND_MESSAGE_LABEL": "Send Message",
             "FORM_ERROR_MESSAGE": "Please fill all variables before sending"

--- a/app/javascript/dashboard/i18n/locale/pt_BR/whatsappTemplates.json
+++ b/app/javascript/dashboard/i18n/locale/pt_BR/whatsappTemplates.json
@@ -17,6 +17,7 @@
         "PARSER": {
             "VARIABLES_LABEL": "Variáveis",
             "VARIABLE_PLACEHOLDER": "Insira o valor para %{variable}",
+            "BUTTON_VARIABLES_LABEL": "Variáveis de botão",
             "GO_BACK_LABEL": "Voltar",
             "SEND_MESSAGE_LABEL": "Enviar Mensagem",
             "FORM_ERROR_MESSAGE": "Por favor, preencha todas as variáveis antes de enviar"

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -155,6 +155,15 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
       }
     end
 
+    Array(template_info[:button_params]).each do |btn|
+      components << {
+        type: 'button',
+        sub_type: 'url',
+        index: btn['index'] || btn[:index],
+        parameters: [{ type: 'text', text: btn['value'] || btn[:value] }]
+      }
+    end
+
     {
       name: template_info[:name],
       language: {

--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -156,11 +156,12 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
     end
 
     Array(template_info[:button_params]).each do |btn|
+      btn = btn.with_indifferent_access
       components << {
         type: 'button',
         sub_type: 'url',
-        index: btn['index'] || btn[:index],
-        parameters: [{ type: 'text', text: btn['value'] || btn[:value] }]
+        index: btn[:index],
+        parameters: [{ type: 'text', text: btn[:value] }]
       }
     end
 

--- a/app/services/whatsapp/send_on_whatsapp_service.rb
+++ b/app/services/whatsapp/send_on_whatsapp_service.rb
@@ -15,7 +15,7 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
   end
 
   def send_template_message
-    name, namespace, lang_code, processed_parameters = processable_channel_message_template
+    name, namespace, lang_code, processed_parameters, button_params = processable_channel_message_template
 
     return if name.blank?
 
@@ -23,7 +23,8 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
                                          name: name,
                                          namespace: namespace,
                                          lang_code: lang_code,
-                                         parameters: processed_parameters
+                                         parameters: processed_parameters,
+                                         button_params: button_params
                                        })
     message.update!(source_id: message_id) if message_id.present?
   end
@@ -35,7 +36,8 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
         template_params['name'],
         template_params['namespace'],
         template_params['language'],
-        template_params['processed_params']&.map { |_, value| { type: 'text', text: value } }
+        template_params['processed_params']&.map { |_, value| { type: 'text', text: value } },
+        template_params['button_params'] || []
       ]
     end
 
@@ -52,9 +54,9 @@ class Whatsapp::SendOnWhatsappService < Base::SendOnChannelService
       processed_parameters = match_obj.captures.map { |x| { type: 'text', text: x } }
 
       # no need to look up further end the search
-      return [template['name'], template['namespace'], template['language'], processed_parameters]
+      return [template['name'], template['namespace'], template['language'], processed_parameters, []]
     end
-    [nil, nil, nil, nil]
+    [nil, nil, nil, nil, []]
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 


### PR DESCRIPTION
 Descrição:                                                      

  ## Resumo

  Templates do WhatsApp do tipo `CALL_TO_ACTION` com botões de URL dinâmicos
  (ex: `iugu.com/invoices/{{1}}`) não tinham suporte para preenchimento da
  variável do botão. Esta PR adiciona o suporte completo, do frontend ao envio via API.

  ## O que foi feito

  - **Frontend (`TemplateParser.vue`):** detecta botões do tipo `URL` com variáveis
    dinâmicas e exibe uma seção "Variáveis de botão" abaixo das variáveis do corpo.
    Cada botão mostra o nome do botão, badge "URL" indicando o tipo, a parte fixa da
    URL como prefixo visual e um campo de input para preencher a variável
  - **Serviço de envio (`send_on_whatsapp_service.rb`):** extrai `button_params` dos
    `template_params` e repassa para o envio do template
  - **Provider da Cloud API (`whatsapp_cloud_service.rb`):** monta os componentes de
    botão (`type: button`, `sub_type: url`) com os parâmetros recebidos no payload
    enviado à API do WhatsApp
  - **i18n (en, pt_BR):** adiciona a chave de tradução `BUTTON_VARIABLES_LABEL`
  
  
  
<img width="623" height="650" alt="image" src="https://github.com/user-attachments/assets/2c4aa8d4-ef5b-4605-91c0-8458663459bc" />
