### PR TITLE
[develop] feat - Capture WhatsApp Flow nfm_reply response data

### DIFF
--- a/app/services/whatsapp/incoming_message_base_service.rb
+++ b/app/services/whatsapp/incoming_message_base_service.rb
@@ -75,7 +75,22 @@ class Whatsapp::IncomingMessageBaseService
     create_message(message)
     attach_files
     attach_location if message_type == 'location'
+    set_flow_response_attributes(message)
     @message.save!
+  end
+
+  def set_flow_response_attributes(message)
+    return unless message_type == 'interactive'
+    return unless message.dig(:interactive, :type) == 'nfm_reply'
+
+    response_json = message.dig(:interactive, :nfm_reply, :response_json)
+    return if response_json.blank?
+
+    @message.content_attributes = (@message.content_attributes || {}).merge(
+      'flow_response' => JSON.parse(response_json)
+    )
+  rescue JSON::ParserError => e
+    Rails.logger.error "Failed to parse flow response JSON: #{e.message}"
   end
 
   def set_contact

--- a/app/services/whatsapp/incoming_message_service_helpers.rb
+++ b/app/services/whatsapp/incoming_message_service_helpers.rb
@@ -30,6 +30,7 @@ module Whatsapp::IncomingMessageServiceHelpers
       message.dig(:button, :text) ||
       message.dig(:interactive, :button_reply, :title) ||
       message.dig(:interactive, :list_reply, :title) ||
+      message.dig(:interactive, :nfm_reply, :body) ||
       message.dig(:name, :formatted_name)
   end
 

--- a/spec/services/whatsapp/incoming_message_service_spec.rb
+++ b/spec/services/whatsapp/incoming_message_service_spec.rb
@@ -344,6 +344,53 @@ describe Whatsapp::IncomingMessageService do
       end
     end
 
+    context 'when valid interactive nfm_reply message (WhatsApp Flow response)' do
+      let(:wa_id) { '2423423243' }
+      let!(:params) do
+        {
+          'contacts' => [{ 'profile' => { 'name' => 'Sojan Jose' }, 'wa_id' => wa_id }],
+          'messages' => [{
+            'from' => wa_id,
+            'id' => 'wamid.flow123',
+            'timestamp' => '1633034394',
+            'type' => 'interactive',
+            'interactive' => {
+              'type' => 'nfm_reply',
+              'nfm_reply' => {
+                'name' => 'flow',
+                'body' => 'Sent',
+                'response_json' => '{"flow_name":"pesquisa_satisfacao","rating1":"5","comment1":"Great"}'
+              }
+            }
+          }]
+        }.with_indifferent_access
+      end
+
+      it 'creates message with content from nfm_reply body' do
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+        message = whatsapp_channel.inbox.messages.last
+        expect(message.content).to eq('Sent')
+      end
+
+      it 'stores flow response in content_attributes' do
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+        message = whatsapp_channel.inbox.messages.last
+        expect(message.content_attributes['flow_response']).to eq({
+          'flow_name' => 'pesquisa_satisfacao',
+          'rating1' => '5',
+          'comment1' => 'Great'
+        })
+      end
+
+      it 'handles malformed response_json gracefully' do
+        params[:messages].first[:interactive][:nfm_reply][:response_json] = 'not-json'
+        described_class.new(inbox: whatsapp_channel.inbox, params: params).perform
+        message = whatsapp_channel.inbox.messages.last
+        expect(message.content).to eq('Sent')
+        expect(message.content_attributes['flow_response']).to be_nil
+      end
+    end
+
     describe 'when message processing is in progress' do
       it 'ignores the current message creation request' do
         params = { 'contacts' => [{ 'profile' => { 'name' => 'Kedar' }, 'wa_id' => '919746334593' }],


### PR DESCRIPTION
Captura de dados de resposta de WhatsApp Flows (nfm_reply) que eram descartados pelo Chatwoot
- Adição de `message.dig(:interactive, :nfm_reply, :body)` no método `message_content` em `incoming_message_service_helpers.rb` para extrair conteúdo de mensagens nfm_reply
- Criação do método `set_flow_response_attributes` em `incoming_message_base_service.rb` que faz parse do `response_json` e armazena em `content_attributes['flow_response']`
- Tratamento de JSON malformado via `rescue JSON::ParserError` com log de erro
- Adição de 3 testes RSpec em `incoming_message_service_spec.rb`: extração de conteúdo, armazenamento de flow_response, e tratamento de JSON inválido