### PR TITLE
fix(conversation): reabre conversa pending quando contato responde em inbox sem bot

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -331,8 +331,16 @@ class Message < ApplicationRecord
     return unless incoming?
 
     conversation.open! if conversation.snoozed?
+    reopen_pending_conversation if conversation.pending?
 
     reopen_resolved_conversation if conversation.resolved?
+  end
+
+  def reopen_pending_conversation
+    return if conversation.inbox.active_bot?
+
+    Current.executed_by = sender if reopened_by_contact?
+    conversation.open!
   end
 
   def reopen_resolved_conversation

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -221,6 +221,23 @@ RSpec.describe Message do
       expect(conversation.open?).to be false
       expect(conversation.pending?).to be true
     end
+
+    it 'reopens pending conversation when the message is from a contact and the inbox has no active bot' do
+      conversation.pending!
+      message.save!
+      expect(message.conversation.open?).to be true
+    end
+
+    it 'keeps pending status when the inbox has an active bot' do
+      agent_bot = create(:agent_bot)
+      inbox = conversation.inbox
+      inbox.agent_bot = agent_bot
+      inbox.save!
+      conversation.pending!
+      message.save!
+      expect(conversation.open?).to be false
+      expect(conversation.pending?).to be true
+    end
   end
 
   describe '#waiting since' do


### PR DESCRIPTION
## Resumo
Conversas em status `pending` em inboxes sem bot ativo ficavam travadas em pending quando o contato respondia. O callback `reopen_conversation` existente só promovia `snoozed → open` e `resolved → open` — `pending` era intencionalmente ignorado porque normalmente significa "bot está controlando".

Para inboxes sem bot (ex.: WhatsApp Cloud API usado direto, sem AgentBot/Dialogflow), uma conversa pending que recebe resposta do contato não tem bot para assumir — então deveria auto-promover para `open` pra que os agentes vejam ela na fila.

## Mudança
- `app/models/message.rb`: novo helper `reopen_pending_conversation` (espelha o `reopen_resolved_conversation` já existente). Encadeado no `reopen_conversation`.
- Inboxes com bot são excluídas via check `active_bot?` — preserva o comportamento atual de fluxo bot-controlled.

## Por que isso importa (contexto downstream)
Usado pela FNLivros para disparar templates de WhatsApp programaticamente. O backend de disparo cria conversas como `pending` (via `POST /api/v1/accounts/.../conversations` com `status: 'pending'`) pra que elas não poluam a fila "Sem Atribuição" quando o cliente nunca responde. Quando o cliente DE FATO responde, a conversa precisa naturalmente aparecer na fila — que é exatamente o que esse patch viabiliza.

## Testes
Dois novos specs em `spec/models/message_spec.rb#reopen_conversation`:
- `pending` + inbox sem bot + incoming → `open`
- `pending` + inbox com bot + incoming → continua `pending` (regression guard)

Os 4 specs existentes desse grupo continuam intocados e sem efeito colateral.

## Impacto comportamental
| Cenário | Antes | Depois |
|---|---|---|
| Conversa pending em inbox com bot, cliente responde | continua pending (bot processa) | continua pending (sem mudança — exclusão via `active_bot?`) |
| Conversa pending em inbox sem bot, cliente responde | travada em pending | promove pra open |
| Conversa marcada como pending manualmente por agente em inbox sem bot, cliente responde | travada em pending | promove pra open (intencional — agente é alertado quando o cliente engaja) |
| Conversas snoozed/resolved | sem mudança | sem mudança |
| Conversas muted | early return | early return (sem mudança) |