### PR TITLE
[develop] feat - Support FLOW button sub_type in WhatsApp Cloud template send

### DIFF
--- a/app/services/whatsapp/providers/whatsapp_cloud_service.rb
+++ b/app/services/whatsapp/providers/whatsapp_cloud_service.rb
@@ -157,12 +157,7 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
 
     Array(template_info[:button_params]).each do |btn|
       btn = btn.with_indifferent_access
-      components << {
-        type: 'button',
-        sub_type: 'url',
-        index: btn[:index],
-        parameters: [{ type: 'text', text: btn[:value] }]
-      }
+      components << build_button_component(btn)
     end
 
     {
@@ -173,6 +168,25 @@ class Whatsapp::Providers::WhatsappCloudService < Whatsapp::Providers::BaseServi
       },
       components: components
     }
+  end
+
+  def build_button_component(btn)
+    case btn[:sub_type].to_s.downcase
+    when 'flow'
+      {
+        type: 'button',
+        sub_type: 'flow',
+        index: btn[:index],
+        parameters: [{ type: 'action', action: { flow_token: btn[:value] } }]
+      }
+    else
+      {
+        type: 'button',
+        sub_type: 'url',
+        index: btn[:index],
+        parameters: [{ type: 'text', text: btn[:value] }]
+      }
+    end
   end
 
   def whatsapp_reply_context(message)

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -193,6 +193,75 @@ describe Whatsapp::Providers::WhatsappCloudService do
         expect(service.send_template('+123456789', template_info)).to eq('message_id')
       end
     end
+
+    context 'when template_info has button_params with sub_type "url"' do
+      let(:template_info_with_url_button) do
+        template_info.merge(button_params: [{ index: 0, value: 'TRACK123' }])
+      end
+
+      let(:expected_body) do
+        body = template_body.deep_dup
+        body[:template][:components] << {
+          type: 'button',
+          sub_type: 'url',
+          index: 0,
+          parameters: [{ type: 'text', text: 'TRACK123' }]
+        }
+        body
+      end
+
+      it 'sends url button with text parameter' do
+        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+          .with(body: expected_body.to_json)
+          .to_return(status: 200, body: whatsapp_response.to_json, headers: response_headers)
+
+        expect(service.send_template('+123456789', template_info_with_url_button)).to eq('message_id')
+      end
+    end
+
+    context 'when template_info has button_params with sub_type "flow"' do
+      let(:template_info_with_flow_button) do
+        template_info.merge(button_params: [{ index: 0, sub_type: 'flow', value: 'tok_abc123' }])
+      end
+
+      let(:expected_body) do
+        body = template_body.deep_dup
+        body[:template][:components] << {
+          type: 'button',
+          sub_type: 'flow',
+          index: 0,
+          parameters: [{ type: 'action', action: { flow_token: 'tok_abc123' } }]
+        }
+        body
+      end
+
+      it 'sends flow button with action+flow_token parameter' do
+        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+          .with(body: expected_body.to_json)
+          .to_return(status: 200, body: whatsapp_response.to_json, headers: response_headers)
+
+        expect(service.send_template('+123456789', template_info_with_flow_button)).to eq('message_id')
+      end
+    end
+
+    context 'when sub_type is omitted (backward compatibility)' do
+      let(:template_info_default) do
+        template_info.merge(button_params: [{ index: 0, value: 'fallback' }])
+      end
+
+      it 'defaults to url sub_type' do
+        stub_request(:post, 'https://graph.facebook.com/v13.0/123456789/messages')
+          .with do |req|
+            JSON.parse(req.body)['template']['components'].any? do |c|
+              c['type'] == 'button' && c['sub_type'] == 'url' &&
+                c['parameters'] == [{ 'type' => 'text', 'text' => 'fallback' }]
+            end
+          end
+          .to_return(status: 200, body: whatsapp_response.to_json, headers: response_headers)
+
+        expect(service.send_template('+123456789', template_info_default)).to eq('message_id')
+      end
+    end
   end
 
   describe '#sync_templates' do

--- a/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
+++ b/spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb
@@ -196,7 +196,7 @@ describe Whatsapp::Providers::WhatsappCloudService do
 
     context 'when template_info has button_params with sub_type "url"' do
       let(:template_info_with_url_button) do
-        template_info.merge(button_params: [{ index: 0, value: 'TRACK123' }])
+        template_info.merge(button_params: [{ index: 0, sub_type: 'url', value: 'TRACK123' }])
       end
 
       let(:expected_body) do


### PR DESCRIPTION
Adição de suporte ao envio de templates com botão FLOW via Cloud API
- Edição de `template_body_parameters` em `app/services/whatsapp/providers/whatsapp_cloud_service.rb` para extrair a construção de cada botão em `build_button_component`
- Quando `button_params[i][:sub_type] == 'flow'`, monta o componente Meta com `sub_type: 'flow'` e `parameters: [{ type: 'action', action: { flow_token: btn[:value] } }]`
- Quando `sub_type` está ausente ou é `'url'`, mantém o comportamento atual (`sub_type: 'url'`, `parameters: [{ type: 'text', text: btn[:value] }]`)
- 3 specs novos em `spec/services/whatsapp/providers/whatsapp_cloud_service_spec.rb`: botão URL explícito, botão FLOW com `flow_token`, e backward compatibility quando `sub_type` está ausente