### PR TITLE
fix: match Brazilian mobile contacts across 9-digit variants

### DIFF
--- a/app/builders/contact_inbox_with_contact_builder.rb
+++ b/app/builders/contact_inbox_with_contact_builder.rb
@@ -81,6 +81,31 @@ class ContactInboxWithContactBuilder
   def find_contact_by_phone_number(phone_number)
     return if phone_number.blank?
 
-    account.contacts.find_by(phone_number: phone_number)
+    account.contacts.where(phone_number: phone_number_lookup_variants(phone_number)).first
+  end
+
+  # Returns the phone number plus its Brazilian 12/13-digit variant when the
+  # number is a BR mobile. Lets us match contacts saved with or without the
+  # leading 9 added in 2012 — upstream integrations and WhatsApp can deliver
+  # either form.
+  def phone_number_lookup_variants(phone_number)
+    digits = phone_number.to_s.gsub(/\D/, '')
+    return [phone_number] unless digits.start_with?('55')
+
+    ddd = digits[2, 2]
+    local = digits[4..].to_s
+
+    case digits.length
+    when 12
+      return [phone_number] unless local[0].to_i.between?(6, 9)
+
+      ["+55#{ddd}9#{local}", "+55#{ddd}#{local}"]
+    when 13
+      return [phone_number] unless local[0] == '9'
+
+      ["+55#{ddd}#{local}", "+55#{ddd}#{local[1..]}"]
+    else
+      [phone_number]
+    end
   end
 end

--- a/app/builders/contact_inbox_with_contact_builder.rb
+++ b/app/builders/contact_inbox_with_contact_builder.rb
@@ -81,31 +81,6 @@ class ContactInboxWithContactBuilder
   def find_contact_by_phone_number(phone_number)
     return if phone_number.blank?
 
-    account.contacts.where(phone_number: phone_number_lookup_variants(phone_number)).first
-  end
-
-  # Returns the phone number plus its Brazilian 12/13-digit variant when the
-  # number is a BR mobile. Lets us match contacts saved with or without the
-  # leading 9 added in 2012 — upstream integrations and WhatsApp can deliver
-  # either form.
-  def phone_number_lookup_variants(phone_number)
-    digits = phone_number.to_s.gsub(/\D/, '')
-    return [phone_number] unless digits.start_with?('55')
-
-    ddd = digits[2, 2]
-    local = digits[4..].to_s
-
-    case digits.length
-    when 12
-      return [phone_number] unless local[0].to_i.between?(6, 9)
-
-      ["+55#{ddd}9#{local}", "+55#{ddd}#{local}"]
-    when 13
-      return [phone_number] unless local[0] == '9'
-
-      ["+55#{ddd}#{local}", "+55#{ddd}#{local[1..]}"]
-    else
-      [phone_number]
-    end
+    account.contacts.where(phone_number: Phone::BrazilianNormalizer.variants(phone_number)).first
   end
 end

--- a/app/helpers/integration_contact_helper.rb
+++ b/app/helpers/integration_contact_helper.rb
@@ -1,12 +1,17 @@
 module IntegrationContactHelper
   def format_phone_number_to_e164(phone_number)
-    digits = phone_number.gsub(/\D/, '')
+    digits = phone_number.to_s.gsub(/\D/, '')
+    digits = "55#{digits}" unless digits.start_with?('55')
 
-    if digits.start_with?('55')
-      "+#{digits}"
-    else
-      "+55#{digits}"
+    # Brazilian mobile numbers received a mandatory leading 9 in 2012. Some
+    # upstream integrations still deliver the legacy 12-digit format; insert
+    # the 9 so we always store the canonical 13-digit form. Landlines (local
+    # prefix 2-5) keep the 12-digit form.
+    if digits.length == 12 && digits[4].to_i.between?(6, 9)
+      digits = "55#{digits[2, 2]}9#{digits[4..]}"
     end
+
+    "+#{digits}"
   end
 
   def build_custom_attributes(order_data, corrupted_data = nil)

--- a/app/helpers/integration_contact_helper.rb
+++ b/app/helpers/integration_contact_helper.rb
@@ -3,15 +3,7 @@ module IntegrationContactHelper
     digits = phone_number.to_s.gsub(/\D/, '')
     digits = "55#{digits}" unless digits.start_with?('55')
 
-    # Brazilian mobile numbers received a mandatory leading 9 in 2012. Some
-    # upstream integrations still deliver the legacy 12-digit format; insert
-    # the 9 so we always store the canonical 13-digit form. Landlines (local
-    # prefix 2-5) keep the 12-digit form.
-    if digits.length == 12 && digits[4].to_i.between?(6, 9)
-      digits = "55#{digits[2, 2]}9#{digits[4..]}"
-    end
-
-    "+#{digits}"
+    Phone::BrazilianNormalizer.canonical("+#{digits}")
   end
 
   def build_custom_attributes(order_data, corrupted_data = nil)

--- a/app/services/integrations/custom_api/create_or_update_contact_service.rb
+++ b/app/services/integrations/custom_api/create_or_update_contact_service.rb
@@ -90,16 +90,20 @@ class Integrations::CustomApi::CreateOrUpdateContactService
     contact = Contact.find_by(account_id: @custom_api['account_id'], email: @account_data['email'], active: true)
     return { :type => 'email', :contact_data => contact } unless contact.nil?
 
-    # Verifica se já existe com base no phone
-    contact = Contact.find_by(account_id: @custom_api['account_id'], phone_number: @formated_phone_number, active: true)
+    # Verifica se já existe com base no phone (incluindo variantes BR de 12/13 dígitos)
+    contact = Contact.where(account_id: @custom_api['account_id'],
+                            phone_number: Phone::BrazilianNormalizer.variants(@formated_phone_number),
+                            active: true).first
     return { :type => 'phone', :contact_data => contact } unless contact.nil?
 
     { type: nil, contact_data: nil }
   end
 
   def find_contact_corrupted(contact_value) # rubocop:disable Metrics/CyclomaticComplexity
-    # Verifica se já existe um contato com o phone_number
-    phone_contact = Contact.where(account_id: @custom_api['account_id'], phone_number: @formated_phone_number, active: true)
+    # Verifica se já existe um contato com o phone_number (incluindo variantes BR de 12/13 dígitos)
+    phone_contact = Contact.where(account_id: @custom_api['account_id'],
+                                  phone_number: Phone::BrazilianNormalizer.variants(@formated_phone_number),
+                                  active: true)
     phone_contact = if contact_value[:type] == 'phone' || contact_value[:type] == 'id_from_integration'
                       phone_contact.find_by("additional_attributes->>'id_from_integration' != ?",
                                             @account_data['id'].to_s)
@@ -133,7 +137,7 @@ class Integrations::CustomApi::CreateOrUpdateContactService
     if contact_ids.length > 1
       corrupted_value = []
       contacts.each do |contact|
-        if contact.phone_number == @formated_phone_number
+        if Phone::BrazilianNormalizer.matches?(contact.phone_number, @formated_phone_number)
           corrupted_value << contact.phone_number
         elsif contact.identifier == @account_data['document']
           corrupted_value << contact.identifier
@@ -142,9 +146,11 @@ class Integrations::CustomApi::CreateOrUpdateContactService
       { contact_corrupted: contact_ids, corrupted_type: 'conflict', corrupted_value: corrupted_value }
     else
       contact = contacts.first
-      if contact.phone_number == @formated_phone_number && contact.identifier == @account_data['document']
+      phone_match = Phone::BrazilianNormalizer.matches?(contact.phone_number, @formated_phone_number)
+
+      if phone_match && contact.identifier == @account_data['document']
         { contact_corrupted: [contact.id], corrupted_type: 'both', corrupted_value: [contact['phone_number'], contact['identifier']] }
-      elsif contact.phone_number == @formated_phone_number
+      elsif phone_match
         { contact_corrupted: [contact.id], corrupted_type: 'phone', corrupted_value: [contact['phone_number']] }
       else
         { contact_corrupted: [contact.id], corrupted_type: 'identifier', corrupted_value: [contact['identifier']] }

--- a/lib/phone/brazilian_normalizer.rb
+++ b/lib/phone/brazilian_normalizer.rb
@@ -43,6 +43,17 @@ module Phone
       variants(phone_number).first
     end
 
+    # Returns true when both inputs refer to the same Brazilian mobile number
+    # regardless of the 12-digit / 13-digit format. Falls back to strict
+    # equality for non-Brazilian or unrecognized inputs. Symmetric on the
+    # canonical form so argument order does not affect the result.
+    def matches?(phone_a, phone_b)
+      return false if phone_a.nil? || phone_b.nil?
+      return true if phone_a == phone_b
+
+      canonical(phone_a) == canonical(phone_b)
+    end
+
     def mobile_local_prefix?(digit)
       return false if digit.nil?
 

--- a/lib/phone/brazilian_normalizer.rb
+++ b/lib/phone/brazilian_normalizer.rb
@@ -1,0 +1,52 @@
+module Phone
+  # Centralizes Brazilian phone number normalization logic.
+  #
+  # Brazilian mobile numbers received a mandatory leading 9 in 2012; integrations
+  # and webhooks may deliver either the 12-digit legacy form or the 13-digit
+  # canonical form. This module exposes both forms so callers can normalize
+  # output (`canonical`) or expand a lookup to match either form (`variants`).
+  #
+  # The 9 is only inserted/stripped for numbers in the historical mobile prefix
+  # range (local first digit 6-9). Landlines (local prefix 2-5) are left
+  # unchanged, as are non-Brazilian numbers and unrecognized lengths.
+  module BrazilianNormalizer
+    module_function
+
+    # Returns an array of E.164 strings: the canonical 13-digit BR mobile form
+    # first, then the legacy 12-digit form. For non-mobile, non-Brazilian, or
+    # unrecognized inputs returns a single-element array with the original
+    # input untouched.
+    def variants(phone_number)
+      digits = phone_number.to_s.gsub(/\D/, '')
+      return [phone_number] unless digits.start_with?('55')
+
+      ddd = digits[2, 2]
+      local = digits[4..].to_s
+
+      case digits.length
+      when 12
+        return [phone_number] unless mobile_local_prefix?(local[0])
+
+        ["+55#{ddd}9#{local}", "+55#{ddd}#{local}"]
+      when 13
+        return [phone_number] unless local[0] == '9'
+
+        ["+55#{ddd}#{local}", "+55#{ddd}#{local[1..]}"]
+      else
+        [phone_number]
+      end
+    end
+
+    # Returns the canonical 13-digit BR mobile form when the input is a BR
+    # mobile, otherwise returns the input unchanged.
+    def canonical(phone_number)
+      variants(phone_number).first
+    end
+
+    def mobile_local_prefix?(digit)
+      return false if digit.nil?
+
+      digit.to_i.between?(6, 9)
+    end
+  end
+end

--- a/spec/builders/contact_inbox_with_contact_builder_spec.rb
+++ b/spec/builders/contact_inbox_with_contact_builder_spec.rb
@@ -95,5 +95,43 @@ describe ContactInboxWithContactBuilder do
 
       expect(contact_inbox.contact.id).to be(contact.id)
     end
+
+    context 'with Brazilian mobile number variants' do
+      let!(:br_contact) { create(:contact, account: account, phone_number: '+5581981132326') }
+
+      it 'matches existing 13-digit contact when lookup uses 12-digit form' do
+        contact_inbox = described_class.new(
+          source_id: '558181132326',
+          inbox: inbox,
+          contact_attributes: { name: 'Lais', phone_number: '+558181132326' }
+        ).perform
+
+        expect(contact_inbox.contact.id).to eq(br_contact.id)
+      end
+
+      it 'matches existing 12-digit contact when lookup uses 13-digit form' do
+        br_contact.update!(phone_number: '+558181132326')
+
+        contact_inbox = described_class.new(
+          source_id: '5581981132326',
+          inbox: inbox,
+          contact_attributes: { name: 'Lais', phone_number: '+5581981132326' }
+        ).perform
+
+        expect(contact_inbox.contact.id).to eq(br_contact.id)
+      end
+
+      it 'does not generate variants for non-Brazilian numbers' do
+        intl_contact = create(:contact, account: account, phone_number: '+12025551234')
+
+        contact_inbox = described_class.new(
+          source_id: 'intl-1',
+          inbox: inbox,
+          contact_attributes: { name: 'Intl', phone_number: '+12025551234' }
+        ).perform
+
+        expect(contact_inbox.contact.id).to eq(intl_contact.id)
+      end
+    end
   end
 end

--- a/spec/helpers/integration_contact_helper_spec.rb
+++ b/spec/helpers/integration_contact_helper_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe IntegrationContactHelper do
+  let(:helper) { Class.new { include IntegrationContactHelper }.new }
+
+  describe '#format_phone_number_to_e164' do
+    context 'when input is a Brazilian mobile in legacy 12-digit format' do
+      it 'inserts the leading 9 (DDD 81)' do
+        expect(helper.format_phone_number_to_e164('558181132326')).to eq('+5581981132326')
+      end
+
+      it 'inserts the leading 9 (DDD 11)' do
+        expect(helper.format_phone_number_to_e164('551188887777')).to eq('+5511988887777')
+      end
+
+      it 'works without country code prefix' do
+        expect(helper.format_phone_number_to_e164('8181132326')).to eq('+5581981132326')
+      end
+
+      it 'strips formatting characters before evaluating length' do
+        expect(helper.format_phone_number_to_e164('+55 (81) 8113-2326')).to eq('+5581981132326')
+      end
+    end
+
+    context 'when input is a Brazilian mobile already in 13-digit format' do
+      it 'returns the canonical E.164 number unchanged' do
+        expect(helper.format_phone_number_to_e164('5581981132326')).to eq('+5581981132326')
+      end
+
+      it 'strips formatting and returns the canonical form' do
+        expect(helper.format_phone_number_to_e164('+55 (81) 98113-2326')).to eq('+5581981132326')
+      end
+    end
+
+    context 'when input is a Brazilian landline (12 digits, local prefix 2-5)' do
+      it 'leaves landlines unchanged (no 9 inserted)' do
+        # São Paulo landline (11) 3030-4040
+        expect(helper.format_phone_number_to_e164('551130304040')).to eq('+551130304040')
+      end
+
+      it 'leaves landlines with local prefix 4 unchanged' do
+        expect(helper.format_phone_number_to_e164('554140005000')).to eq('+554140005000')
+      end
+    end
+  end
+end

--- a/spec/lib/phone/brazilian_normalizer_spec.rb
+++ b/spec/lib/phone/brazilian_normalizer_spec.rb
@@ -58,4 +58,35 @@ RSpec.describe Phone::BrazilianNormalizer do
       expect(described_class.canonical('+12025551234')).to eq('+12025551234')
     end
   end
+
+  describe '.matches?' do
+    it 'matches the same BR mobile across 12-digit and 13-digit forms' do
+      expect(described_class.matches?('+558181132326', '+5581981132326')).to be true
+      expect(described_class.matches?('+5581981132326', '+558181132326')).to be true
+    end
+
+    it 'returns true for identical inputs' do
+      expect(described_class.matches?('+5581981132326', '+5581981132326')).to be true
+    end
+
+    it 'returns false for different BR mobile numbers' do
+      expect(described_class.matches?('+5581981132326', '+5581988887777')).to be false
+    end
+
+    it 'is symmetric (argument order does not change the result)' do
+      expect(described_class.matches?('+558181132326', '+5581981132326'))
+        .to eq(described_class.matches?('+5581981132326', '+558181132326'))
+    end
+
+    it 'does not match a BR landline against a mobile that shares the same trailing 8 digits' do
+      expect(described_class.matches?('+551130304040', '+5511930304040')).to be false
+      expect(described_class.matches?('+5511930304040', '+551130304040')).to be false
+    end
+
+    it 'returns false for nil inputs' do
+      expect(described_class.matches?(nil, '+5581981132326')).to be false
+      expect(described_class.matches?('+5581981132326', nil)).to be false
+      expect(described_class.matches?(nil, nil)).to be false
+    end
+  end
 end

--- a/spec/lib/phone/brazilian_normalizer_spec.rb
+++ b/spec/lib/phone/brazilian_normalizer_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Phone::BrazilianNormalizer do
+  describe '.variants' do
+    context 'with a 12-digit Brazilian mobile (legacy, no leading 9)' do
+      it 'returns the canonical 13-digit form first and the legacy form second' do
+        expect(described_class.variants('+558181132326')).to eq(['+5581981132326', '+558181132326'])
+      end
+
+      it 'works with DDD 11 mobile prefixes' do
+        expect(described_class.variants('+551188887777')).to eq(['+5511988887777', '+551188887777'])
+      end
+    end
+
+    context 'with a 13-digit Brazilian mobile (canonical, leading 9)' do
+      it 'returns the canonical form first and the 12-digit legacy form second' do
+        expect(described_class.variants('+5581981132326')).to eq(['+5581981132326', '+558181132326'])
+      end
+    end
+
+    context 'with a Brazilian landline (12 digits, local prefix 2-5)' do
+      it 'returns only the input unchanged' do
+        expect(described_class.variants('+551130304040')).to eq(['+551130304040'])
+      end
+    end
+
+    context 'with a non-Brazilian number' do
+      it 'returns only the input unchanged' do
+        expect(described_class.variants('+12025551234')).to eq(['+12025551234'])
+      end
+    end
+
+    context 'with a blank or unrecognized input' do
+      it 'returns the input unchanged when it has an unexpected length' do
+        expect(described_class.variants('+5511')).to eq(['+5511'])
+      end
+
+      it 'handles nil safely by returning the original input' do
+        expect(described_class.variants(nil)).to eq([nil])
+      end
+    end
+  end
+
+  describe '.canonical' do
+    it 'returns the 13-digit canonical form for a legacy 12-digit BR mobile' do
+      expect(described_class.canonical('+558181132326')).to eq('+5581981132326')
+    end
+
+    it 'returns the canonical form unchanged when already 13 digits' do
+      expect(described_class.canonical('+5581981132326')).to eq('+5581981132326')
+    end
+
+    it 'leaves landlines unchanged' do
+      expect(described_class.canonical('+551130304040')).to eq('+551130304040')
+    end
+
+    it 'leaves non-Brazilian numbers unchanged' do
+      expect(described_class.canonical('+12025551234')).to eq('+12025551234')
+    end
+  end
+end

--- a/spec/services/integrations/custom_api/create_or_update_contact_service_spec.rb
+++ b/spec/services/integrations/custom_api/create_or_update_contact_service_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe Integrations::CustomApi::CreateOrUpdateContactService do
+  let(:account) { create(:account) }
+  let(:custom_api) { { 'account_id' => account.id, 'name' => 'Quickshop' } }
+
+  let(:account_data_with_9) do
+    {
+      'id' => 'QS-1001',
+      'firstName' => 'Lais',
+      'lastName' => 'Porto',
+      'email' => 'lais@example.com',
+      'document' => '00000000000',
+      'phoneNumber' => '5581981132326'
+    }
+  end
+
+  let(:account_data_without_9) do
+    account_data_with_9.merge('phoneNumber' => '558181132326')
+  end
+
+  let(:order_data) { { 'account' => account_data_with_9 } }
+
+  describe '#perform' do
+    context 'Path A — Quickshop creates contact, second Quickshop call uses 12-digit form' do
+      it 'reuses the existing 13-digit canonical contact' do
+        existing = create(:contact, account: account, phone_number: '+5581981132326',
+                                     additional_attributes: { 'integration' => 'Quickshop',
+                                                              'id_from_integration' => 'QS-1001' })
+
+        expect do
+          described_class.new(nil, custom_api, account_data_without_9).perform
+        end.not_to change(Contact, :count)
+
+        existing.reload
+        expect(existing.phone_number).to eq('+5581981132326')
+      end
+    end
+
+    context 'Path B — WhatsApp created contact first, Quickshop arrives later with different format' do
+      it 'updates the existing 12-digit WhatsApp contact instead of creating a duplicate' do
+        wa_contact = create(:contact, account: account, phone_number: '+558181132326', email: nil, identifier: nil)
+
+        expect do
+          described_class.new(nil, custom_api, account_data_with_9).perform
+        end.not_to change(Contact, :count)
+
+        wa_contact.reload
+        expect(wa_contact.phone_number).to eq('+5581981132326')
+        expect(wa_contact.identifier).to eq('00000000000')
+        expect(wa_contact.additional_attributes['id_from_integration']).to eq('QS-1001')
+      end
+
+      it 'updates the existing 13-digit WhatsApp contact when Quickshop sends 12-digit form' do
+        wa_contact = create(:contact, account: account, phone_number: '+5581981132326', email: nil, identifier: nil)
+
+        expect do
+          described_class.new(nil, custom_api, account_data_without_9).perform
+        end.not_to change(Contact, :count)
+
+        wa_contact.reload
+        expect(wa_contact.identifier).to eq('00000000000')
+      end
+    end
+
+    context 'when no existing contact matches' do
+      it 'creates a new contact with the canonical 13-digit phone' do
+        expect do
+          described_class.new(order_data, custom_api, nil).perform
+        end.to change(Contact, :count).by(1)
+
+        contact = Contact.last
+        expect(contact.phone_number).to eq('+5581981132326')
+        expect(contact.email).to eq('lais@example.com')
+        expect(contact.identifier).to eq('00000000000')
+      end
+    end
+
+    context 'when phone matches a contact owned by a different Quickshop integration id' do
+      it 'classifies the existing contact as phone-corrupted using variant matching' do
+        create(:contact, account: account, phone_number: '+558181132326',
+                         additional_attributes: { 'integration' => 'Quickshop',
+                                                  'id_from_integration' => 'QS-OTHER' })
+
+        expect do
+          described_class.new(nil, custom_api, account_data_with_9).perform
+        end.to change(Contact, :count).by(1)
+
+        new_contact = Contact.where("additional_attributes->>'id_from_integration' = ?", 'QS-1001').first
+        expect(new_contact.custom_attributes['corrupted_type']).to eq('phone')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Corrige duplicação de contatos quando a integração Quickshop e o webhook do WhatsApp armazenam o mesmo número em formatos brasileiros diferentes (12 vs 13 dígitos, com/sem o "9" obrigatório do celular pós-2012). Auditoria em produção mostrou 1107 grupos duplicados nesse padrão, divididos em ~50% Path A (Quickshop primeiro) e ~50% Path B (WhatsApp primeiro).

- `format_phone_number_to_e164` em `IntegrationContactHelper` agora insere o "9" automaticamente em números BR de 12 dígitos com prefixo de celular (6-9). Linhas fixas (prefixo 2-5) continuam preservadas no formato de 12 dígitos.
- `find_contact_by_phone_number` em `ContactInboxWithContactBuilder` passou a consultar o número original junto das variantes BR de 12 e 13 dígitos numa única query `WHERE IN`, evitando criar contato duplicado quando o WhatsApp entrega o número em formato diferente do salvo pelo Quickshop. Números não-BR mantêm o comportamento de match exato.
- Lookups de `first_contact` e `find_contact_corrupted` em `Integrations::CustomApi::CreateOrUpdateContactService` agora também usam variantes BR, evitando duplicação quando o WhatsApp salvou o contato primeiro (Path B).
- Comparações de `phone_number` em `find_corrupted_data` passaram a usar `Phone::BrazilianNormalizer.matches?` para preservar a classificação correta de `corrupted_type` quando os formatos divergem.
- Lógica de detecção/normalização de celular BR centralizada em `lib/phone/brazilian_normalizer.rb` (`variants`, `canonical`, `matches?`), eliminando duplicação entre helper, builder e service.
- Specs novas em `spec/lib/phone/brazilian_normalizer_spec.rb` e `spec/services/integrations/custom_api/create_or_update_contact_service_spec.rb` cobrindo Path A, Path B, criação de contato novo e classificação de conflito.
- Specs estendidas em `spec/builders/contact_inbox_with_contact_builder_spec.rb` cobrindo o matching cruzado das variantes BR e a preservação do match exato para números não-BR.

Correção forward-only — contatos duplicados existentes em produção não são migrados por este PR.

Linear: https://linear.app/flavianasser/issue/FN-137/ana-rubia-costa-geralmente-o-cadastro-da-quickshop-gera-um-cadastro