### PR TITLE
chore: reduce chatwoot restart cron from 4h to 2h

### DIFF
--- a/.github/workflows/websocket_restarter.yml
+++ b/.github/workflows/websocket_restarter.yml
@@ -2,7 +2,7 @@ name: Hourly restarter Job
 
 on:
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 */2 * * *'
 
 jobs:
   run-cron-job:


### PR DESCRIPTION
Mitigação paliativa de instabilidade do Chatwoot. Cron de restart automático passa a executar a cada 2 horas em vez de 4 horas.

- Alteração da expressão cron de `0 */4 * * *` para `0 */2 * * *` em `.github/workflows/websocket_restarter.yml`
- Restart automático passa de 6×/dia para 12×/dia (00, 02, 04, 06, 08, 10, 12, 14, 16, 18, 20, 22 UTC)
- Solução temporária enquanto refatoração de infra do Chatwoot não é concluída — reduz janela de acúmulo de pressão em pool de conexões e memória entre restarts