### PR TITLE
chore(env): set RAILS_MAX_THREADS=25 in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,7 @@ POSTGRES_PASSWORD=
 RAILS_ENV=development
 # Changes the Postgres query timeout limit. The default is 14 seconds. Modify only when required.
 # POSTGRES_STATEMENT_TIMEOUT=14s
-RAILS_MAX_THREADS=5
+RAILS_MAX_THREADS=25
 
 # The email from which all outgoing emails are sent
 # could user either  `email@yourdomain.com` or `BrandName <email@yourdomain.com>`


### PR DESCRIPTION
## Summary

- Bumps `RAILS_MAX_THREADS` from `5` to `25` in `.env.example`
- Ports a hotfix that's been live on production since 2026-05-11

## Context

Default value of `5` was saturating the ActiveRecord connection pool in production, causing cascading `ActiveRecord::ConnectionTimeoutError` and HTTP 500s during business hours. `RAILS_MAX_THREADS` controls both Puma thread count AND the AR pool size (`config/database.yml` uses it as the pool value).

Timeline:
- 2026-05-11 18:58 UTC — applied `RAILS_MAX_THREADS=15` directly on prod host (`.env`) to recover from incident
- 2026-05-14 21:13 UTC — pool of 15 was reaching ceiling consistently in CloudWatch (DatabaseConnections sustained at 25/25). Bumped to 25 on host.

This PR ports the value to the repo so future host re-creations preserve it.

## What changes

- `.env.example`: `RAILS_MAX_THREADS=5` → `RAILS_MAX_THREADS=25`

## Risk

Low. The production host already runs with this value. Merging only updates what new deployments / fresh checkouts will see by default.

## Test plan

- [ ] Validate that future `docker compose up -d` from this repo brings the rails container up with `RAILS_MAX_THREADS=25`
- [ ] Confirm AR pool size on a fresh boot equals 25

## Linear refs

- [FN-145](https://linear.app/flavianasser/issue/FN-145) — port hotfix to repo (this PR closes it)
- [FN-147](https://linear.app/flavianasser/issue/FN-147) — incident investigation that triggered the original hotfix