### PR TITLE
fix(twilio): retry media download with auth to handle staging race

### DIFF
--- a/app/services/twilio/incoming_message_service.rb
+++ b/app/services/twilio/incoming_message_service.rb
@@ -125,6 +125,8 @@ class Twilio::IncomingMessageService
     @message.save!
   end
 
+  MEDIA_DOWNLOAD_RETRY_DELAY = 2.seconds
+
   def download_attachment_file
     download_with_auth
   rescue Down::Error, Down::ClientError => e
@@ -139,12 +141,15 @@ class Twilio::IncomingMessageService
     )
   end
 
-  # This is just a temporary workaround since some users have not yet enabled media protection. We will remove this in the future.
+  # Twilio sometimes fires the inbound webhook before the media is fully staged at
+  # the MediaUrl (race condition, especially for externally-hosted media that Twilio
+  # has to fetch and re-host). Retry once with auth after a short delay before giving up.
   def handle_download_attachment_error(error)
-    Rails.logger.info "Error downloading attachment from Twilio: #{error.message}: Retrying"
-    Down.download(params[:MediaUrl0])
+    Rails.logger.warn "[Twilio] Media download failed on first attempt for message #{@message&.id} (MediaUrl=#{params[:MediaUrl0]}): #{error.class}: #{error.message}. Retrying in #{MEDIA_DOWNLOAD_RETRY_DELAY}s."
+    sleep MEDIA_DOWNLOAD_RETRY_DELAY
+    download_with_auth
   rescue StandardError => e
-    Rails.logger.info "Error downloading attachment from Twilio: #{e.message}: Skipping"
+    Rails.logger.error "[Twilio] Media download FAILED after retry for message #{@message&.id} (MediaUrl=#{params[:MediaUrl0]}): #{e.class}: #{e.message}"
     nil
   end
 end

--- a/spec/services/twilio/incoming_message_service_spec.rb
+++ b/spec/services/twilio/incoming_message_service_spec.rb
@@ -199,10 +199,11 @@ describe Twilio::IncomingMessageService do
 
     context 'when there is an error downloading the attachment' do
       before do
-        stub_request(:get, 'https://chatwoot-assets.local/sample.png')
-          .to_raise(Down::Error.new('Download error'))
+        # Skip the retry delay so the test runs instantly.
+        allow_any_instance_of(described_class).to receive(:sleep)
 
         stub_request(:get, 'https://chatwoot-assets.local/sample.png')
+          .to_raise(Down::Error.new('Download error')).then
           .to_return(status: 200, body: 'image data', headers: {})
       end
 
@@ -219,7 +220,7 @@ describe Twilio::IncomingMessageService do
         }
       end
 
-      it 'retries downloading the attachment without a token after an error' do
+      it 'retries downloading the attachment with auth after a transient error' do
         expect do
           described_class.new(params: params_with_attachment_error).perform
         end.not_to raise_error
@@ -227,6 +228,37 @@ describe Twilio::IncomingMessageService do
         expect(conversation.reload.messages.last.content).to eq('testing3')
         expect(conversation.reload.messages.last.attachments.count).to eq(1)
         expect(conversation.reload.messages.last.attachments.first.file_type).to eq('image')
+      end
+    end
+
+    context 'when the attachment download fails on both attempts' do
+      before do
+        allow_any_instance_of(described_class).to receive(:sleep)
+
+        stub_request(:get, 'https://chatwoot-assets.local/sample.png')
+          .to_raise(Down::Error.new('Download error'))
+      end
+
+      let(:params_with_persistent_error) do
+        {
+          SmsSid: 'SMxx',
+          From: '+12345',
+          AccountSid: 'ACxxx',
+          MessagingServiceSid: twilio_channel.messaging_service_sid,
+          Body: 'persistent failure',
+          NumMedia: '1',
+          MediaContentType0: 'image/jpeg',
+          MediaUrl0: 'https://chatwoot-assets.local/sample.png'
+        }
+      end
+
+      it 'creates the message without an attachment and does not raise' do
+        expect do
+          described_class.new(params: params_with_persistent_error).perform
+        end.not_to raise_error
+
+        expect(conversation.reload.messages.last.content).to eq('persistent failure')
+        expect(conversation.reload.messages.last.attachments.count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
## Resumo

  - `Twilio::IncomingMessageService#handle_download_attachment_error` agora retenta o download via `download_with_auth` (após um `sleep` curto)
   em vez de baixar sem autenticação — corrige a perda silenciosa de anexos em contas com **Media Access Protection** ligada.
  - Falhas no retry agora são logadas em nível `error` em vez de `info`, para que o problema fique visível nos logs de produção; a mensagem em
  si continua sendo preservada (o método retorna `nil`).
  - A spec foi atualizada para usar respostas encadeadas do WebMock (`.then`) e stubar o `sleep`; uma nova spec cobre o caso em que **as duas
  tentativas falham**.

  ## Causa raiz

  O webhook inbound do Twilio às vezes dispara **antes da mídia anexada estar totalmente disponível** no `MediaUrl` — comportamento típico em
  MMS quando o Twilio precisa baixar e re-hospedar mídia externa. A primeira chamada `Down.download(MediaUrl)` retorna um erro transitório.

  O caminho de retry anterior (`Down.download(url)` **sem** HTTP basic auth) está quebrado em qualquer conta com **Media Access Protection**
  habilitada (o default recomendado pela Twilio): a tentativa sem auth retorna `401`, o `rescue` engole o erro e o anexo é descartado
  silenciosamente. O comentário `# This is just a temporary workaround...` no código antecede a Media Access Protection virar default.

  ## Reprodução

  Conta com Media Access Protection ON, inbox Twilio Messaging Service configurada no Chatwoot:

  1. `curl ... Messages.json -d MediaUrl=https://www.w3.org/.../dummy.pdf` (PDF hospedado externamente)
  2. Twilio dispara o webhook inbound → Chatwoot persiste o body da mensagem **mas sem o anexo**
  3. Nos logs aparece apenas `Error downloading attachment from Twilio: ...: Skipping` em nível `info`
  4. Reenviar o **mesmo payload** alguns minutos depois anexa normalmente (race condition dependente de timing)

  Teste de controle na mesma sessão com `MediaUrl=https://demo.twilio.com/owl.png` (imagem já em CDN do próprio Twilio, sem delay de staging)
  anexou de primeira sem problema — confirmando que o gargalo está na janela entre webhook e disponibilidade da mídia no S3 da Twilio.